### PR TITLE
v1.2.0 Feature - Parameterizable Messages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,37 @@
+{
+    "env": {
+        "browser": true,
+        "es6": true
+    },
+    "extends": [
+        "airbnb"
+    ],
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "parserOptions": {
+        "ecmaFeatures": {
+            "jsx": true
+        },
+        "ecmaVersion": 2018,
+        "sourceType": "module"
+    },
+    "plugins": [
+        "react",
+        "react-hooks"
+    ],
+    "rules": {
+        // Indent with 4 spaces
+        "indent": ["error", 4],
+
+        // Indent JSX with 4 spaces
+        "react/jsx-indent": ["error", 4],
+
+        // Indent props with 4 spaces
+        "react/jsx-indent-props": ["error", 4],
+
+        "react-hooks/rules-of-hooks": "error",
+        "react-hooks/exhaustive-deps": "warn"
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ react-language-kit.js
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# VS Code
+/.vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -1823,9 +1823,9 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-      "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
       "dev": true
     },
     "acorn-walk": {
@@ -4546,6 +4546,28 @@
         }
       }
     },
+    "eslint-config-airbnb": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.0.1.tgz",
+      "integrity": "sha512-hLb/ccvW4grVhvd6CT83bECacc+s4Z3/AEyWQdIT2KeTsG9dR7nx1gs7Iw4tDmGKozCNHFn4yZmRm3Tgy+XxyQ==",
+      "dev": true,
+      "requires": {
+        "eslint-config-airbnb-base": "^14.0.0",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.0"
+      }
+    },
+    "eslint-config-airbnb-base": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.0.0.tgz",
+      "integrity": "sha512-2IDHobw97upExLmsebhtfoD3NAKhV4H0CJWP3Uprd/uk+cHuWYOczPVxQ8PxLFUAw7o3Th1RAU8u1DoUpr+cMA==",
+      "dev": true,
+      "requires": {
+        "confusing-browser-globals": "^1.0.7",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.0"
+      }
+    },
     "eslint-config-react-app": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-5.0.2.tgz",
@@ -4823,20 +4845,20 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.14.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
-      "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.16.0.tgz",
+      "integrity": "sha512-GacBAATewhhptbK3/vTP09CbFrgUJmBSaaRcWdbQLFvUZy9yVcQxigBNHGPU/KE2AyHpzj3AWXpxoMTsIDiHug==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
         "doctrine": "^2.1.0",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^2.1.0",
+        "jsx-ast-utils": "^2.2.1",
         "object.entries": "^1.1.0",
         "object.fromentries": "^2.0.0",
         "object.values": "^1.1.0",
         "prop-types": "^15.7.2",
-        "resolve": "^1.10.1"
+        "resolve": "^1.12.0"
       },
       "dependencies": {
         "doctrine": {
@@ -4882,13 +4904,13 @@
       "dev": true
     },
     "espree": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-      "integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+      "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
       "dev": true,
       "requires": {
-        "acorn": "^7.0.0",
-        "acorn-jsx": "^5.0.2",
+        "acorn": "^7.1.0",
+        "acorn-jsx": "^5.1.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
@@ -6766,6 +6788,25 @@
         "ipaddr.js": "^1.9.0"
       }
     },
+    "intl-format-cache": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-4.2.3.tgz",
+      "integrity": "sha512-9UMBxp/SduF9BESfuWaZqv61tT/s4RkD13MGmG/tmUHPdue201nU5R571stWSsOA87Z5gT4b1L4JzZXhO0IY+g=="
+    },
+    "intl-messageformat": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-7.3.3.tgz",
+      "integrity": "sha512-LfYzzoUYjDtdZDDmntOAEYkub816ZWpWFqv2pXXNv7Ea5WUUltljHOxwQXEly54rNk6whkn97rxfu3LPFRzmFw==",
+      "requires": {
+        "intl-format-cache": "^4.2.3",
+        "intl-messageformat-parser": "^3.2.2"
+      }
+    },
+    "intl-messageformat-parser": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-3.2.2.tgz",
+      "integrity": "sha512-ax9639ST77YimAddTH/0Q9qhXuYS8ZVsoqOZinqnS90MbXaNuIq+KIdifaIndwI+lMEv3o+qNaGycXYvlh17rw=="
+    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -7951,9 +7992,9 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
-      "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
+      "integrity": "sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
@@ -10858,6 +10899,32 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "eslint-plugin-react": {
+          "version": "7.14.3",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
+          "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
+          "dev": true,
+          "requires": {
+            "array-includes": "^3.0.3",
+            "doctrine": "^2.1.0",
+            "has": "^1.0.3",
+            "jsx-ast-utils": "^2.1.0",
+            "object.entries": "^1.1.0",
+            "object.fromentries": "^2.0.0",
+            "object.values": "^1.1.0",
+            "prop-types": "^15.7.2",
+            "resolve": "^1.10.1"
           }
         },
         "fsevents": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-language-kit",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7835,8 +7835,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -8238,7 +8237,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -8872,8 +8870,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -10519,7 +10516,6 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -10797,8 +10793,7 @@
     "react-is": {
       "version": "16.10.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
-      "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==",
-      "dev": true
+      "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
     },
     "react-scripts": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "react-language-kit",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "A React internationalization (i18n) helper with minimal footprint and ease of usage",
   "main": "react-language-kit.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "react-scripts start",
     "build": "./node_modules/.bin/babel src/react-language-kit --out-file react-language-kit.js"
   },
@@ -37,6 +36,12 @@
     "@babel/core": "^7.6.4",
     "@babel/preset-env": "^7.6.3",
     "@babel/preset-react": "^7.6.3",
+    "eslint": "^6.5.1",
+    "eslint-config-airbnb": "^18.0.1",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-react": "^7.16.0",
+    "eslint-plugin-react-hooks": "^1.7.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
     "react-scripts": "3.2.0"
@@ -55,5 +60,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "dependencies": {
+    "intl-messageformat": "^7.3.3"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -6,11 +6,11 @@ export default function App() {
 	return (
 		<LanguageProvider
 			//v1.0.0
-			language={'pt'}
-			languages={['en', 'pt']}
+			language={'pt-BR'}
+			languages={['en-US', 'pt-BR']}
 			//v1.1.0 and above
-			activeLanguage={'pt'}
-			availableLanguages={['en', 'pt']}
+			activeLanguage={'pt-BR'}
+			availableLanguages={['en-US', 'pt-BR']}
 		>
 			<RetrocompatPage />
 		</LanguageProvider>

--- a/src/pages/Retrocompat/V1.2.0.jsx
+++ b/src/pages/Retrocompat/V1.2.0.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useActiveLanguage, useAvailableLanguages, useTranslation } from '../../react-language-kit';
+import { useActiveLanguage, useAvailableLanguages, useTranslation } from 'react-language-kit';
 
 import Section from './Section';
 import i18nMap from './i18n';
@@ -19,14 +19,10 @@ const formats = {
 
 export default function V1_2_0() {
     const [language, setLanguage] = useActiveLanguage();
-    const [options, setLanguageOptions] = useAvailableLanguages();
+    const [options] = useAvailableLanguages();
 
     /** New Hook! ('formats' is optional) */
     const t = useTranslation(i18nMap, formats);
-
-    const shuffleLanguages = () => {
-        setLanguageOptions((opts) => [...opts].reverse());
-    };
 
     return (
         <Section
@@ -43,10 +39,6 @@ export default function V1_2_0() {
                     </select>
 
                     <br />
-
-                    <button type="button" onClick={() => shuffleLanguages()}>
-                        {t('button')}
-                    </button>
 
                     <hr />
                     <h1>{t('formatArgs')}</h1>

--- a/src/pages/Retrocompat/V1.2.0.jsx
+++ b/src/pages/Retrocompat/V1.2.0.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { useActiveLanguage, useAvailableLanguages, useTranslation } from '../../react-language-kit';
+
+import Section from './Section';
+import i18nMap from './i18n';
+
+const version = { v: '1.2.0' };
+
+/**
+ * Currency code list at:
+ * https://www.currency-iso.org/dam/downloads/lists/list_one.xml
+ */
+const formats = {
+    number: {
+        usd: { style: 'currency', currency: 'USD' },
+        brl: { style: 'currency', currency: 'BRL' },
+    },
+};
+
+export default function V1_2_0() {
+    const [language, setLanguage] = useActiveLanguage();
+    const [options, setLanguageOptions] = useAvailableLanguages();
+
+    /** New Hook! ('formats' is optional) */
+    const t = useTranslation(i18nMap, formats);
+
+    const shuffleLanguages = () => {
+        setLanguageOptions((opts) => [...opts].reverse());
+    };
+
+    return (
+        <Section
+            title={t('versionWithParam', version)}
+            description={`${t('description')}: ${language}`}
+            options={(
+                <>
+                    <select value={language} onChange={(e) => setLanguage(e.target.value)}>
+                        {
+                            options.map((option) => (
+                                <option key={option} value={option}>{option.toUpperCase()}</option>
+                            ))
+                        }
+                    </select>
+
+                    <br />
+
+                    <button type="button" onClick={() => shuffleLanguages()}>
+                        {t('button')}
+                    </button>
+
+                    <hr />
+                    <h1>{t('formatArgs')}</h1>
+
+                    <h5>{t('formatArgs.percentUsage')}</h5>
+                    <p>{t('formattedArgument.percentUsage', { numCats: '27', pctBlack: 0.75 })}</p>
+
+                    <h5>{t('formatArgs.dateUsage')}</h5>
+                    <p>{t('formattedArgument.dateUsage', { start: new Date() })}</p>
+
+                    <h5>{t('formatArgs.timeUsage')}</h5>
+                    <p>{t('formattedArgument.timeUsage', { expires: new Date() })}</p>
+
+                    <h5>{t('formatArgs.currencyUsage')}</h5>
+                    <p>{t('formattedArgument.currencyUsage', { total: '10' })}</p>
+
+                    <h5>{t('formatArgs.selectUsage')}</h5>
+                    <p>{t('formattedArgument.selectUsage', { gender: 'male' })}</p>
+                    <p>{t('formattedArgument.selectUsage', { gender: 'female' })}</p>
+                    <p>{t('formattedArgument.selectUsage', { gender: 'other' })}</p>
+
+                    <h5>{t('formatArgs.pluralUsage')}</h5>
+                    <p>{t('formattedArgument.pluralUsage', { itemCount: 0 })}</p>
+                    <p>{t('formattedArgument.pluralUsage', { itemCount: 1 })}</p>
+                    <p>{t('formattedArgument.pluralUsage', { itemCount: 22 })}</p>
+
+                    <h5>{t('fallbackTest')}</h5>
+                    <p>{t('fallbackValue')}</p>
+
+                </>
+            )}
+        />
+    );
+}

--- a/src/pages/Retrocompat/V1.2.0_classComponent.jsx
+++ b/src/pages/Retrocompat/V1.2.0_classComponent.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { withActiveLanguage, withAvailableLanguages, useTranslationTo } from 'react-language-kit';
+
+import Section from './Section';
+import i18nMap from './i18n';
+
+const version = { v: '1.2.0' };
+
+class V120ClassComponent extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {};
+    }
+
+    render() {
+        const { activeLanguage, availableLanguages } = this.props;
+        const [language, setLanguage] = activeLanguage;
+        const [options] = availableLanguages;
+        const t = useTranslationTo(language, i18nMap);
+
+        return (
+            <Section
+                title={t('versionCompatibleCC', version)}
+                description={`${t('description')}: ${language}`}
+                options={(
+                    <>
+                        <select value={language} onChange={(e) => setLanguage(e.target.value)}>
+                            {
+                                options.map((option) => (
+                                    <option key={option} value={option}>{option.toUpperCase()}</option>
+                                ))
+                            }
+                        </select>
+
+                        <br />
+
+                        <hr />
+                        <h1>{t('formatArgs')}</h1>
+
+                        <h5>{t('formatArgs.percentUsage')}</h5>
+                        <p>{t('formattedArgument.percentUsage', { numCats: '27', pctBlack: 0.75 })}</p>
+
+                        <h5>{t('formatArgs.dateUsage')}</h5>
+                        <p>{t('formattedArgument.dateUsage', { start: new Date() })}</p>
+
+                        <h5>{t('formatArgs.timeUsage')}</h5>
+                        <p>{t('formattedArgument.timeUsage', { expires: new Date() })}</p>
+
+                        <h5>{t('formatArgs.currencyUsage')}</h5>
+                        <p>{t('formattedArgument.currencyUsage', { total: '10' })}</p>
+
+                        <h5>{t('formatArgs.selectUsage')}</h5>
+                        <p>{t('formattedArgument.selectUsage', { gender: 'male' })}</p>
+                        <p>{t('formattedArgument.selectUsage', { gender: 'female' })}</p>
+                        <p>{t('formattedArgument.selectUsage', { gender: 'other' })}</p>
+
+                        <h5>{t('formatArgs.pluralUsage')}</h5>
+                        <p>{t('formattedArgument.pluralUsage', { itemCount: 0 })}</p>
+                        <p>{t('formattedArgument.pluralUsage', { itemCount: 1 })}</p>
+                        <p>{t('formattedArgument.pluralUsage', { itemCount: 22 })}</p>
+
+                        <h5>{t('fallbackTest')}</h5>
+                        <p>{t('fallbackValue')}</p>
+
+                    </>
+                )}
+            />
+        );
+    }
+}
+
+export default withAvailableLanguages(withActiveLanguage(V120ClassComponent));

--- a/src/pages/Retrocompat/i18n.js
+++ b/src/pages/Retrocompat/i18n.js
@@ -7,6 +7,7 @@ export default {
         button: 'Revert languages list!',
 
         versionWithParam: 'Version (with params) {v}',
+        versionCompatibleCC: 'Version {v} (compatible with Class Components)',
 
         formatArgs: 'Formatted Arguments',
         'formatArgs.percentUsage': 'Percent Usage',
@@ -36,6 +37,7 @@ export default {
         button: 'Inverter lista de idiomas!',
 
         versionWithParam: 'Versão (com parametros) {v}',
+        versionCompatibleCC: 'Versão {v} (compatível com Class Components)',
 
         formatArgs: 'Argumentos formatados',
         'formatArgs.percentUsage': 'Uso de porcentagem',

--- a/src/pages/Retrocompat/i18n.js
+++ b/src/pages/Retrocompat/i18n.js
@@ -1,16 +1,59 @@
 export default {
-	en: {
-		title: 'Retrocompatibility test',
-		version: 'Version',
-		description: 'Currently using',
-		options: 'Options',
-		button: 'Revert languages list!',
-	},
-	pt: {
-		title: 'Teste de retrocompatibilidade',
-		version: 'Versão',
-		description: 'Atualmente usando',
-		options: 'Opções',
-		button: 'Inverter lista de idiomas!',
-	},
-}
+    'en-US': {
+        title: 'Retrocompatibility test',
+        version: 'Version',
+        description: 'Currently using',
+        options: 'Options',
+        button: 'Revert languages list!',
+
+        versionWithParam: 'Version (with params) {v}',
+
+        formatArgs: 'Formatted Arguments',
+        'formatArgs.percentUsage': 'Percent Usage',
+        'formatArgs.dateUsage': 'Date Usage',
+        'formatArgs.timeUsage': 'Time Usage',
+        'formatArgs.currencyUsage': 'Currency Usage',
+        'formatArgs.selectUsage': 'Select Usage',
+        'formatArgs.pluralUsage': 'Plural Usage',
+
+        formattedArgument: {
+            percentUsage: 'I have {numCats, number} cats. Almost {pctBlack, number, percent} of them are black.',
+            dateUsage: 'Sale begins {start, date, long}',
+            timeUsage: 'Coupon expires at {expires, time, short}',
+            currencyUsage: 'Your total is {total, number, usd}',
+            selectUsage: '{gender, select, male {He} female {She} other {They} } will respond shortly.',
+            pluralUsage: 'You have {itemCount, plural, =0 {no items} one {# item} other {# items} }.',
+        },
+
+        fallbackTest: 'Fallback Test',
+        fallbackValue: 'term defined only in the json file for the en-US locale',
+    },
+    'pt-BR': {
+        title: 'Teste de retrocompatibilidade',
+        version: 'Versão',
+        description: 'Atualmente usando',
+        options: 'Opções',
+        button: 'Inverter lista de idiomas!',
+
+        versionWithParam: 'Versão (com parametros) {v}',
+
+        formatArgs: 'Argumentos formatados',
+        'formatArgs.percentUsage': 'Uso de porcentagem',
+        'formatArgs.dateUsage': 'Uso de data',
+        'formatArgs.timeUsage': 'Uso de tempo',
+        'formatArgs.currencyUsage': 'Uso de moeda',
+        'formatArgs.selectUsage': 'Uso de seleção',
+        'formatArgs.pluralUsage': 'Uso de plural',
+
+        formattedArgument: {
+            percentUsage: 'Eu Tenho {numCats, number} gatos. Cerca de {pctBlack, number, percent} deles são pretos.',
+            dateUsage: 'As vendas começam em {start, date, long}',
+            timeUsage: 'O cupom expira às {expires, time, short}',
+            currencyUsage: 'Seu total é {total, number, brl}',
+            selectUsage: '{gender, select, male {Ele} female {Ela} other {Ele(a)} } responderá em breve.',
+            pluralUsage: 'Você {itemCount, plural, =0 {não tem itens} one {tem # item} other {tem # itens} }.',
+        },
+
+        fallbackTest: 'Teste de recuperação de falha (termo é buscado no locale padrão)',
+    },
+};

--- a/src/pages/Retrocompat/index.js
+++ b/src/pages/Retrocompat/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 import V100 from './V1.0.0';
 import V110 from './V1.1.0';
 import V120 from './V1.2.0';
+import V120ClassComponent from './V1.2.0_classComponent';
 
 export default function RetrocompatPage() {
 	return (
@@ -16,6 +17,7 @@ export default function RetrocompatPage() {
 			<V100 />
 			<V110 />
             <V120 />
+            <V120ClassComponent />
 		</div>
 	);
 }

--- a/src/pages/Retrocompat/index.js
+++ b/src/pages/Retrocompat/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import V100 from './V1.0.0';
 import V110 from './V1.1.0';
+import V120 from './V1.2.0';
 
 export default function RetrocompatPage() {
 	return (
@@ -14,6 +15,7 @@ export default function RetrocompatPage() {
 		}}>
 			<V100 />
 			<V110 />
+            <V120 />
 		</div>
 	);
 }

--- a/src/react-language-kit/index.js
+++ b/src/react-language-kit/index.js
@@ -101,6 +101,30 @@ export const useLanguage = () => useContext(LanguageContext);
 export const useActiveLanguage = () => useContext(ActiveLanguageContext);
 export const useAvailableLanguages = () => useContext(AvailableLanguagesContext);
 
+export const withLanguage = (Component) => (
+    (props) => (
+        <LanguageContext.Consumer>
+            {(context) => <Component language={context} {...props} />}
+        </LanguageContext.Consumer>
+    )
+);
+
+export const withActiveLanguage = (Component) => (
+    (props) => (
+        <ActiveLanguageContext.Consumer>
+            {(context) => <Component activeLanguage={context} {...props} />}
+        </ActiveLanguageContext.Consumer>
+    )
+);
+
+export const withAvailableLanguages = (Component) => (
+    (props) => (
+        <AvailableLanguagesContext.Consumer>
+            {(context) => <Component availableLanguages={context} {...props} />}
+        </AvailableLanguagesContext.Consumer>
+    )
+);
+
 /* For use at the top level of your React function (Hooks rules) */
 export const useTranslation = (dictionaries = {}, formats) => {
     const [language] = useActiveLanguage();

--- a/src/react-language-kit/index.js
+++ b/src/react-language-kit/index.js
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useReducer } from 'react';
+import IntlMessageFormat from 'intl-messageformat';
 
 const defaultLanguage = 'en-US';
 
@@ -20,7 +21,7 @@ function showUsage() {
 }
 
 export default function LanguageProvider({children, languages, language, activeLanguage, availableLanguages}) {
-	
+
 	const options = languages || [ defaultLanguage ];
 	language = language || defaultLanguage;
 
@@ -53,3 +54,51 @@ export default function LanguageProvider({children, languages, language, activeL
 export const useLanguage = () => useContext(LanguageContext);
 export const useActiveLanguage = () => useContext(ActiveLanguageContext);
 export const useAvailableLanguages = () => useContext(AvailableLanguagesContext);
+
+export const useTranslation = (dictionaries = {}, formats) => {
+    const [language] = useActiveLanguage();
+
+    /**
+     * ==Inner Function==
+     * get the raw meaning of a dictionary term
+     * @param {Object} dictionary The JSON object used as term dictionary
+     * @param {string} term The string representing a dictionary term
+     * @returns {string} The meaning of the term in the dictionary
+     */
+    function translate(dictionary = {}, term) {
+        if (dictionary[term]) {
+            return dictionary[term];
+        }
+        return term.split('.').reduce((a, b) => ((a !== undefined) ? a[b] : a), dictionary);
+    }
+
+    /**
+     * get the meaning of a dictionary term
+     * @param {string} term The string representing a dictionary term
+     * @param {Object} parameters Replacement parameters
+     * @returns {string} The meaning rendered to the term in the dictionary
+     */
+    return (term = '', parameters) => {
+        /* translate the term into the current language */
+        let msg = translate(dictionaries[language], term);
+        if (msg == null) {
+            /* If the term does not exist in the current language,
+             * it translates into the default language */
+            msg = translate(dictionaries[defaultLanguage], term);
+            if (msg == null) {
+                /* Fallback if term is not found */
+                return term;
+            }
+        }
+        if (!parameters) {
+            /* shortcut to avoid unnecessary processing */
+            return msg;
+        }
+        try {
+            const msgFormatter = new IntlMessageFormat(msg, language, formats);
+            return msgFormatter.format(parameters);
+        } catch (err) {
+            return msg;
+        }
+    };
+};


### PR DESCRIPTION
This feature includes:
- Display numbers, currency, dates and times for different locales.
- Pluralize labels in strings.
- Support variables in message.
- Message format is strictly implemented by ICU standards.
- Locale data in nested JSON format are supported.

New React Hook:
- useTranslation

This hook receives an object with several dictionaries as parameter,
each dictionary must contain the definition (according to locale) for
each of the terms used by the application that uses this lib.
A second parameter can be optionally passed to customize number and
date formatting.

This hook returns a function capable of translating a Term according
to the current set locale. The function takes two parameters, the first
is the term to be translated, the second (optional) is a key/value object
used in case of parameterizable messages.

This feature makes use of 'intl-messageformat' lib. For more details see:
https://github.com/formatjs/intl-messageformat
This lib is based on the specification ECMAScript Internationalization API 4.0
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl


**In the second commit support for vanilla javascript added**
Submit a non-hook version. For this, the programmer would have to manually inform Language, something like:
```
export const useTranslationTo = (language, dictionaries = {}, formats) => {
    // do not use the hook, because the language was passed by parameter
}
```
